### PR TITLE
Set quantized values

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -16,7 +16,8 @@ setGeneric(name = "buildCellTypeIndex",
            def = function(sce,
                           dataset.name = '',
                           assay.name = 'logcounts',
-                          cell.type.label = 'cell_type1')
+                          cell.type.label = 'cell_type1',
+                          qb = 2)
            {
                standardGeneric("buildCellTypeIndex")
            })

--- a/R/CoreMethods.R
+++ b/R/CoreMethods.R
@@ -6,6 +6,7 @@
 #' @param dataset.name name of the dataset that will be prepended in each cell_type
 #' @param assay.name name of the SingleCellExperiment assay that will be considered for the generation of the index
 #' @param cell.type.label the cell.type metadata of the colData SingleCellExperiment that will be used for the index
+#' @param qb number of bits per cell that are going to be used for quantile compression of the expression data
 #' 
 #' @name buildCellTypeIndex
 #'
@@ -19,7 +20,7 @@
 #' @importFrom Rcpp cpp_object_initializer
 #' @useDynLib scfind 
 #' 
-buildCellTypeIndex.SCESet <- function(sce, dataset.name, assay.name = 'counts', cell.type.label = 'cell_type1')
+buildCellTypeIndex.SCESet <- function(sce, dataset.name, assay.name = 'counts', cell.type.label = 'cell_type1', qb = 2)
 {
 
     if (grepl(dataset.name,'.'))
@@ -49,6 +50,12 @@ buildCellTypeIndex.SCESet <- function(sce, dataset.name, assay.name = 'counts', 
         exprs <- "[["(sce@assays$data, assay.name)
 
         ef <- new(EliasFanoDB)
+       
+        qb.set <- ef$setQB(qb)
+        if (qb.set == 1)
+        {
+            stop("Setting the quantization bits failed")
+        }
         for (cell.type in cell.types) {
             inds.cell <- which(cell.type == cell.types.all)
             if(length(inds.cell) < 2)

--- a/src/EliasFano.h
+++ b/src/EliasFano.h
@@ -208,6 +208,10 @@ class EliasFanoDB
 
   void clearDB();
  
+  int setQuantizationBits(const unsigned int value);
+
+  unsigned int getQuantizationBits() const;
+
   const EliasFano& getEntry(const GeneName& gene_name, const CellTypeName& cell_type) const;
  
   int loadByteStream(const Rcpp::RawVector& stream);


### PR DESCRIPTION
Different number quantization_bits can be used while building the index

during index build time the qb option can be passed in the `buildCellTypeIndex(sce,dataset.name, qb = 4)`

defaults to 2


TODO:
@thjimmylee 
- test retrieving of these values is not creating problems