### PR TITLE
Slight confusing typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ __A__: Please use [this page](https://github.com/hemberg-lab/scfind/issues).
 
 __Q__: Is __scfind__ published?  
 
-__A__: Not yet, but a copy of __scmap__ manuscript is available on [bioRxiv](https://doi.org/10.1101/788596).
+__A__: Not yet, but a copy of __scfind__ manuscript is available on [bioRxiv](https://doi.org/10.1101/788596).
 
 __Q__: What is __scfind__ licence?
 


### PR DESCRIPTION
Slight typo corrected which confused me upon the first read---it's obvious in retrospect, but that's retrospect. 

Also, the image at https://genat.uk/img/scfind2_colour.png within the markdown doesn't render

CC @wikiselev @thjimmylee @pati-ni 