### PR TITLE
[FIX] Expose class to R

### DIFF
--- a/src/EliasFano.h
+++ b/src/EliasFano.h
@@ -11,6 +11,9 @@
 #include "const.h"
 #include "typedef.h"
 
+
+
+
 //' @export EliasFanoDB 
 class EliasFanoDB
 {
@@ -163,4 +166,5 @@ class EliasFanoDB
 
 };
 
+RCPP_EXPOSED_CLASS(EliasFanoDB)
 

--- a/src/eliasFano.cpp
+++ b/src/eliasFano.cpp
@@ -1190,5 +1190,3 @@ RCPP_MODULE(EliasFanoDB)
     .method("evaluateCellTypeMarkers", &EliasFanoDB::evaluateCellTypeMarkers)
     .method("getCellTypeSupport", &EliasFanoDB::getCellTypeSupport);
 }
-
-


### PR DESCRIPTION
Fix of a bug, due to refactoring.

Directive in the header file so functions are exposed to the R environment. Without the `RCPP_EXPOSED_CLASS` it is not possible to pass the `class EliasFanoDB` as an argument from the R environment. Now `Rcpp::as` and `Rcpp::wrap` are provided by Rcpp during compile time.

@thjimmylee 